### PR TITLE
Util proportion filler

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@ Add minimal html markup and styles to prevent margins from collapsing.
 
 ```util-uncollapse-margin```
 
+## Proportion filler 
+Creates an element with a fixed ratio which can be used to sync with another element's min-height.  
+
+```util-proportion-filler```
+
 ## Random number 
 Get a random number between a min and max value.  
 

--- a/util-proportion-filler.xsl
+++ b/util-proportion-filler.xsl
@@ -40,7 +40,7 @@
 		<add data-sync-property-with="height" />
 		<add data-sync-property-from=".js-proportion-filler" />
 		<xsl:if test="$has-ancestor">
-			<add data-sync-property-from-common-ancestor=".js-module-card-over-media" />
+			<add data-sync-property-from-common-ancestor="{$ancestor}" />
 		</xsl:if>
 	</xsl:template>
 </xsl:stylesheet>

--- a/util-proportion-filler.xsl
+++ b/util-proportion-filler.xsl
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+<!-- COMPONENT: util-proportion-filler -->
+	<xsl:template name="util-proportion-filler">
+		<xsl:param name="attr" />
+
+
+		<!-- COMPUTED ATTRIBUTES -->
+		<xsl:variable name="computed-attr">
+			<add class="absolute width-full left pointer-events-none" />
+			<add class="js-proportion-filler" />
+			<add dev-component="util-proportion-filler-ctn" />
+		</xsl:variable>
+
+		<xsl:variable name="computed-attr">
+			<add class="width-full" />
+			<xsl:copy-of select="$attr"/>
+			<add dev-component="util-proportion-filler" />
+		</xsl:variable>
+
+		<!-- STRUCTURE -->
+		<xsl:call-template name="element">
+			<xsl:with-param name="attr" select="$computed-attr-ctn" />
+			<xsl:with-param name="content">
+				<xsl:call-template name="element">
+					<xsl:with-param name="attr" select="$computed-attr" />
+				</xsl:call-template>
+			</xsl:with-param> 
+		</xsl:call-template>
+	</xsl:template>
+
+<!-- COMPONENT: util-proportion-filler-attr -->
+	<xsl:template name="util-proportion-filler-attr">
+		<xsl:param name="ancestor" />
+		<xsl:variable name="has-ancestor" select="string-length($ancestor) != 0" />
+		
+		<add class="js-auto-sync-property" />
+		<add data-sync-property="min-height" />
+		<add data-sync-property-with="height" />
+		<add data-sync-property-from=".js-proportion-filler" />
+		<xsl:if test="$has-ancestor">
+			<add data-sync-property-from-common-ancestor=".js-module-card-over-media" />
+		</xsl:if>
+	</xsl:template>
+</xsl:stylesheet>

--- a/util-proportion-filler.xsl
+++ b/util-proportion-filler.xsl
@@ -7,7 +7,7 @@
 
 
 		<!-- COMPUTED ATTRIBUTES -->
-		<xsl:variable name="computed-attr">
+		<xsl:variable name="computed-attr-ctn">
 			<add class="absolute width-full left pointer-events-none" />
 			<add class="js-proportion-filler" />
 			<add dev-component="util-proportion-filler-ctn" />

--- a/util-rewrite-node.xsl
+++ b/util-rewrite-node.xsl
@@ -36,7 +36,7 @@
 	Transform all h tag in div with h tag as class
 
 	<xsl:template match="h1 | h2 | h3 | h4 | h5 | h6" mode="rewrite-node">
-		<div class="name()">
+		<div class="{name()}">
 			<xsl:apply-templates select="@* | node() | text()" mode="rewrite-node"/>
 		</div>
 	</xsl:template> 


### PR DESCRIPTION
Propportion filler is useful to create an empty element of a fixed ratio. This element can then be used to sync another element's min-height. This enables a container to have a min-height of a fixed ratio that can also expend if its content needs to.